### PR TITLE
`find_indices()`

### DIFF
--- a/src/iter/find_indices.rs
+++ b/src/iter/find_indices.rs
@@ -1,0 +1,56 @@
+use crate::pattern::NewlinePattern;
+use core::iter::FusedIterator;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FindIndices<'a, NP> {
+    pattern: &'a NP,
+    s: &'a str,
+    offset: usize,
+}
+
+impl<'a, NP> FindIndices<'a, NP> {
+    pub(crate) fn new(pattern: &'a NP, s: &'a str) -> Self {
+        FindIndices {
+            pattern,
+            s,
+            offset: 0,
+        }
+    }
+}
+
+impl<NP: NewlinePattern> Iterator for FindIndices<'_, NP> {
+    type Item = (usize, usize);
+
+    fn next(&mut self) -> Option<(usize, usize)> {
+        if self.s.is_empty() {
+            return None;
+        }
+        let Some((start, end)) = self.pattern.search(self.s) else {
+            self.s = "";
+            return None;
+        };
+        self.s = &self.s[end..];
+        let start = start.saturating_add(self.offset);
+        let end = end.saturating_add(self.offset);
+        self.offset = end;
+        Some((start, end))
+    }
+}
+
+impl<NP: NewlinePattern> FusedIterator for FindIndices<'_, NP> {}
+
+impl<NP: NewlinePattern> DoubleEndedIterator for FindIndices<'_, NP> {
+    fn next_back(&mut self) -> Option<(usize, usize)> {
+        if self.s.is_empty() {
+            return None;
+        }
+        let Some((start, end)) = self.pattern.rsearch(self.s) else {
+            self.s = "";
+            return None;
+        };
+        self.s = &self.s[..start];
+        let start = start.saturating_add(self.offset);
+        let end = end.saturating_add(self.offset);
+        Some((start, end))
+    }
+}

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1,6 +1,7 @@
 //! Iterator types
 mod complement;
 mod diff;
+mod find_indices;
 mod inner;
 mod intersection;
 mod into_iter;
@@ -8,6 +9,7 @@ mod symdiff;
 mod union;
 pub use self::complement::*;
 pub use self::diff::*;
+pub use self::find_indices::*;
 pub use self::intersection::*;
 pub use self::into_iter::*;
 pub use self::symdiff::*;

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,3 +1,4 @@
+use crate::iter::FindIndices;
 use crate::nl::Newline;
 use crate::nlset::NewlineSet;
 
@@ -13,6 +14,13 @@ mod private {
 pub trait NewlinePattern: private::Sealed {
     fn search(&self, s: &str) -> Option<(usize, usize)>;
     fn rsearch(&self, s: &str) -> Option<(usize, usize)>;
+
+    fn find_indices<'a>(&'a self, s: &'a str) -> FindIndices<'a, Self>
+    where
+        Self: Sized,
+    {
+        FindIndices::new(self, s)
+    }
 }
 
 impl NewlinePattern for Newline {
@@ -180,4 +188,15 @@ mod tests {
             }
         }
     }
+
+    // newline: find_indices()
+    //  CR ~ \r\r\n
+    //  CRLF ~ \r\r\n
+    //  rev()
+    //  next() mixed with next_back()
+
+    // newline set: find_indices()
+    //  {CR, CRLF} ~ \r\r\n
+    //  rev()
+    //  next() mixed with next_back()
 }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -187,6 +187,99 @@ mod tests {
                 assert!(nlset.contains(Newline::try_from(&s[start..end]).unwrap()));
             }
         }
+
+        mod find_indices {
+            use super::*;
+
+            mod ascii {
+                use super::*;
+
+                #[test]
+                fn empty() {
+                    let mut iter = NewlineSet::ASCII.find_indices("");
+                    assert_eq!(iter.next(), None);
+                    assert_eq!(iter.next(), None);
+                    assert_eq!(iter.next_back(), None);
+                    assert_eq!(iter.next_back(), None);
+                }
+
+                #[test]
+                fn no_newline() {
+                    let mut iter = NewlineSet::ASCII.find_indices("foobar");
+                    assert_eq!(iter.next(), None);
+                    assert_eq!(iter.next(), None);
+                    assert_eq!(iter.next_back(), None);
+                    assert_eq!(iter.next_back(), None);
+                }
+
+                #[rstest]
+                #[case("\n", (0, 1))]
+                #[case("\r", (0, 1))]
+                #[case("\r\n", (0, 2))]
+                #[case("foo\n", (3, 4))]
+                #[case("foo\r", (3, 4))]
+                #[case("foo\r\n", (3, 5))]
+                #[case("\nfoo", (0, 1))]
+                #[case("\rfoo", (0, 1))]
+                #[case("\r\nfoo", (0, 2))]
+                #[case("foo\nbar", (3, 4))]
+                #[case("foo\rbar", (3, 4))]
+                #[case("foo\r\nbar", (3, 5))]
+                #[case("foo“\n”bar", (6, 7))]
+                #[case("foo“\r”bar", (6, 7))]
+                #[case("foo“\r\n”bar", (6, 8))]
+                fn one_newline(#[case] s: &str, #[case] value: (usize, usize)) {
+                    let mut iter = NewlineSet::ASCII.find_indices(s);
+                    assert_eq!(iter.next(), Some(value));
+                    assert_eq!(iter.next(), None);
+                    assert_eq!(iter.next(), None);
+                    assert_eq!(iter.next_back(), None);
+                    assert_eq!(iter.next_back(), None);
+                    let mut riter = NewlineSet::ASCII.find_indices(s);
+                    assert_eq!(riter.next_back(), Some(value));
+                    assert_eq!(riter.next_back(), None);
+                    assert_eq!(riter.next_back(), None);
+                    assert_eq!(riter.next(), None);
+                    assert_eq!(riter.next(), None);
+                }
+
+                #[rstest]
+                #[case("\n\r", (0, 1), (1, 2))]
+                #[case("foo\n\rbar", (3, 4), (4, 5))]
+                #[case("foo\n\nbar", (3, 4), (4, 5))]
+                #[case("foo\r\rbar", (3, 4), (4, 5))]
+                #[case("foo\nbar\n", (3, 4), (7, 8))]
+                #[case("foo\rbar\r", (3, 4), (7, 8))]
+                #[case("foo\r\nbar\r\n", (3, 5), (8, 10))]
+                fn two_newlines(
+                    #[case] s: &str,
+                    #[case] nel1: (usize, usize),
+                    #[case] nel2: (usize, usize),
+                ) {
+                    let mut iter = NewlineSet::ASCII.find_indices(s);
+                    assert_eq!(iter.next(), Some(nel1));
+                    assert_eq!(iter.next(), Some(nel2));
+                    assert_eq!(iter.next(), None);
+                    assert_eq!(iter.next(), None);
+                    assert_eq!(iter.next_back(), None);
+                    assert_eq!(iter.next_back(), None);
+                    let mut riter = NewlineSet::ASCII.find_indices(s);
+                    assert_eq!(riter.next_back(), Some(nel2));
+                    assert_eq!(riter.next_back(), Some(nel1));
+                    assert_eq!(riter.next_back(), None);
+                    assert_eq!(riter.next_back(), None);
+                    assert_eq!(riter.next(), None);
+                    assert_eq!(riter.next(), None);
+                    let mut diter = NewlineSet::ASCII.find_indices(s);
+                    assert_eq!(diter.next(), Some(nel1));
+                    assert_eq!(diter.next_back(), Some(nel2));
+                    assert_eq!(diter.next(), None);
+                    assert_eq!(diter.next(), None);
+                    assert_eq!(diter.next_back(), None);
+                    assert_eq!(diter.next_back(), None);
+                }
+            }
+        }
     }
 
     // newline: find_indices()


### PR DESCRIPTION
Closes #2.

To Do:

- [ ] Should `NewlinePattern::find_indices()` consume `self` and require it to be `Copy`?